### PR TITLE
Altera XMLHttpRequest para fetch API

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
 		<blockquote id="estrofe"></blockquote>
 		<p class="poeta" id="poeta"></p>
 
-		<a href="" onclick="declamar(event)" class="button">Declamar outra poesia</a>
+		<a href="#" class="declare-button button">Declamar outra poesia</a>
 		
 		<div class="share">
 			<div class="fb-like item" data-href="https://www.facebook.com/filosofunksite/" data-layout="button_count" data-action="like" data-size="large" data-show-faces="true" data-share="false"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -12,14 +12,28 @@ ready(onReady);
 
 function onReady() {
     getPoetry();
+    declarePoetry();
 }
 
 function randomNumber(totalelements) {
     return Math.floor(Math.random() * totalelements);
 }
+function setStorage(data) {
+    localStorage.setItem('shuffle', JSON.stringify(data));
+}
+function getStorage() {
+    return JSON.parse(localStorage.getItem('shuffle'));
+}
 
+function getIndex(storageData) {
+    return storageData.shift() || 0;
+}
+
+let poetry; // global para ser usada no button :/
 function setPoetry(data) {
-    let storage = JSON.parse(localStorage.getItem('shuffle'));
+    let storage = getStorage();
+
+    poetry = data;
 
     if (!storage || !storage.length) {
         let total = data.length;
@@ -37,10 +51,9 @@ function setPoetry(data) {
         storage = shuffle;
     }
 
-    let index = storage.shift() || 0;
+    let index = getIndex(storage);
     exibirPoesia(data[index]);
-    localStorage.setItem('shuffle', JSON.stringify(storage));
-
+    setStorage(storage);
 }
 
 async function getPoetry() {
@@ -50,9 +63,8 @@ async function getPoetry() {
             let data = await response.json();
             setPoetry(data);
         }
-
     } catch (error) {
-        throw new Error('Erro ao obter dados do JSON', error);
+        throw new Error(`Erro ao obter dados do JSON: ${error}`);
     }
 }
 
@@ -62,13 +74,17 @@ function exibirPoesia(poesia) {
     document.getElementById("poesia").innerText = poesia.poesia;
 }
 
-//que coisa feia
-function declamar(event) {
-    event.preventDefault();
-    var ds = JSON.parse(localStorage.getItem("shuffle"));
-    if (!ds || !ds.length) {
-        window.location.reload();
-    }
-    exibirPoesia(data[ds.shift() || 0]);
-    localStorage.setItem("shuffle", JSON.stringify(ds));
+function declarePoetry() {
+    document.querySelector('.declare-button').addEventListener('click', (evt) => {
+        evt.preventDefault();
+        let storage = getStorage();
+
+        if (!storage || !storage.length) {
+            window.location.reload();
+        };
+
+        let index = getIndex(storage);
+        exibirPoesia(poetry[index]);
+        setStorage(storage);
+    });
 }

--- a/js/app.js
+++ b/js/app.js
@@ -18,6 +18,36 @@ function randomNumber(totalelements) {
     return Math.floor(Math.random() * totalelements);
 }
 
+fetch('poesias.json').then(res => {
+    if (res.status === 200) {
+        return res.json();
+    }
+}).then(data => {
+    let storage = localStorage.getItem('shuffle');
+
+    if (!storage || !storage.length) {
+        let total = data.length;
+
+        let shuffle = data.map((t, index) => {
+            let key = randomNumber(total);
+
+            if (!data[key]) {
+                data[key] = index;
+                return data[key];
+            }
+        });
+
+        storage = shuffle;
+    }
+
+
+    localStorage.setItem('shuffle', storage);
+
+
+}).catch(error => {
+    console.error('Erro ao obter dados do Json');
+});
+
 // substituindo $.getJSON()
 var request = new XMLHttpRequest();
 request.open('GET', './poesias.json', true); // Dev
@@ -26,24 +56,24 @@ request.onload = function () {
 
         window.data = JSON.parse(request.responseText);
 
-        var ds = JSON.parse(localStorage.getItem("shuffle"));
+        //var ds = JSON.parse(localStorage.getItem("shuffle"));
 
-        if (!ds || !ds.length) {
-            var dataShufle = [];
-            var maxRandom = data.length;
+        // if (!ds || !ds.length) {
+        //     var dataShufle = [];
+        //     var maxRandom = data.length;
 
-            for (var i = 0; i < maxRandom;){
-                var key = randomNumber(data.length)
-                if (!dataShufle[key]) {
-                    dataShufle[key] = i;
-                    i++
-                }
-            }
-            ds = dataShufle;
-        }
+        //     for (var i = 0; i < maxRandom;) {
+        //         var key = randomNumber(data.length)
+        //         if (!dataShufle[key]) {
+        //             dataShufle[key] = i;
+        //             i++
+        //         }
+        //     }
+        //     //ds = dataShufle;
+        // }
 
-        exibirPoesia(data[ds.shift() || 0]);
-        localStorage.setItem("shuffle", JSON.stringify(ds));
+        //exibirPoesia(data[ds.shift() || 0]);
+        //localStorage.setItem("shuffle", JSON.stringify(ds));
     } else {
         console.log("Falha ao obter dados do Json");
     }
@@ -62,7 +92,7 @@ function exibirPoesia(poesia) {
 function declamar(event) {
     event.preventDefault();
     var ds = JSON.parse(localStorage.getItem("shuffle"));
-    if (!ds || !ds.length){
+    if (!ds || !ds.length) {
         window.location.reload();
     }
     exibirPoesia(data[ds.shift() || 0]);

--- a/js/app.js
+++ b/js/app.js
@@ -11,76 +11,50 @@ function ready(fn) {
 ready(onReady);
 
 function onReady() {
-    request.send();
+    getPoetry();
 }
 
 function randomNumber(totalelements) {
     return Math.floor(Math.random() * totalelements);
 }
 
-fetch('poesias.json').then(res => {
-    if (res.status === 200) {
-        return res.json();
-    }
-}).then(data => {
-    let storage = localStorage.getItem('shuffle');
+function setPoetry(data) {
+    let storage = JSON.parse(localStorage.getItem('shuffle'));
 
     if (!storage || !storage.length) {
         let total = data.length;
+        let shuffle = [];
 
-        let shuffle = data.map((t, index) => {
+        for (let i = 0; i < total;) {
             let key = randomNumber(total);
 
-            if (!data[key]) {
-                data[key] = index;
-                return data[key];
+            if (!shuffle[key]) {
+                shuffle[key] = i;
+                i++;
             }
-        });
+        }
 
         storage = shuffle;
     }
 
+    let index = storage.shift() || 0;
+    exibirPoesia(data[index]);
+    localStorage.setItem('shuffle', JSON.stringify(storage));
 
-    localStorage.setItem('shuffle', storage);
+}
 
+async function getPoetry() {
+    try {
+        let response = await fetch('poesias.json');
+        if (response.status === 200) {
+            let data = await response.json();
+            setPoetry(data);
+        }
 
-}).catch(error => {
-    console.error('Erro ao obter dados do Json');
-});
-
-// substituindo $.getJSON()
-var request = new XMLHttpRequest();
-request.open('GET', './poesias.json', true); // Dev
-request.onload = function () {
-    if (request.status >= 200 && request.status < 400) {
-
-        window.data = JSON.parse(request.responseText);
-
-        //var ds = JSON.parse(localStorage.getItem("shuffle"));
-
-        // if (!ds || !ds.length) {
-        //     var dataShufle = [];
-        //     var maxRandom = data.length;
-
-        //     for (var i = 0; i < maxRandom;) {
-        //         var key = randomNumber(data.length)
-        //         if (!dataShufle[key]) {
-        //             dataShufle[key] = i;
-        //             i++
-        //         }
-        //     }
-        //     //ds = dataShufle;
-        // }
-
-        //exibirPoesia(data[ds.shift() || 0]);
-        //localStorage.setItem("shuffle", JSON.stringify(ds));
-    } else {
-        console.log("Falha ao obter dados do Json");
+    } catch (error) {
+        throw new Error('Erro ao obter dados do JSON', error);
     }
-};
-request.onerror = function () {
-    console.log("Erro ao obter dados do Json");
-};
+}
 
 function exibirPoesia(poesia) {
     document.getElementById("estrofe").innerText = '"' + poesia.estrofe + '"';


### PR DESCRIPTION
Achei bem interessante a ideia do projeto, por isso resolvi dar uma olhada mais "profunda" no código e vi que estava usando `XMLHttpRequest` para fazer a requisição do "poesias.json". Nos dias atuais, temos a [fetch API](https://caniuse.com/#search=fetch) que é uma maneira simples para chamadas AJAX de maneira mais "eficientes". Sem contar que a fetch API é baseada em Promise, no qual pode obter mais "poder" para controlar tais requisições. Dai, surgiu a ideia de ajudar com isso. 

Como precisaria usar as alterações em outro contexto (no clique do botão), fiz alteração nele também. 

Existem outras ideias no qual gostaria de ajudar, mas acho que vale a pena abrir uma discussão. :crab: 

Qualquer coisa, estamos ai!!