### PR TITLE
Adicionado playback de música

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,9 @@
 		<h1>Filosofunk</h1>
 		<h6>Lindas frases para aquecer os corações</h6>
 	</header>
-
+	
+	<iframe width="0" height="0" id="musica" src="" frameborder="0" allow="autoplay; encrypted-media" ></iframe>
+	
 	<div class="container">
 		<p class="titulo">Trecho de "<span id="poesia"></span>"</p>
 		<blockquote id="estrofe"></blockquote>

--- a/js/app.js
+++ b/js/app.js
@@ -66,7 +66,7 @@ function exibirPoesia(poesia) {
     document.getElementById("estrofe").innerText = '"' + poesia.estrofe + '"';
     document.getElementById("poeta").innerText = poesia.poeta;
     document.getElementById("poesia").innerText = poesia.poesia;
-    carregarMusica('N4Q4j1oSdUU', 41);
+    carregarMusica(poesia.id, poesia.start);
 }
 
 //que coisa feia

--- a/js/app.js
+++ b/js/app.js
@@ -52,10 +52,21 @@ request.onerror = function () {
     console.log("Erro ao obter dados do Json");
 };
 
+/**
+ * Carrega o iframe com a música do youtube
+ * @param id - ID do vídeo no youtube
+ * @param start - Tempo de início do vídeo
+ */
+function carregarMusica(id, start) {
+    var src = 'https://www.youtube.com/embed/' + id + '?loop=1&autoplay=1&start=' + start;
+    document.getElementById("musica").src = src;
+}
+
 function exibirPoesia(poesia) {
     document.getElementById("estrofe").innerText = '"' + poesia.estrofe + '"';
     document.getElementById("poeta").innerText = poesia.poeta;
     document.getElementById("poesia").innerText = poesia.poesia;
+    carregarMusica('N4Q4j1oSdUU', 41);
 }
 
 //que coisa feia

--- a/poesias.json
+++ b/poesias.json
@@ -1,312 +1,434 @@
-[
-    {
+[  
+    {  
         "estrofe": "Foca mas não sufoca",
         "poesia": "Ta Tranquilo Ta Favorável",
-        "poeta": "Mc Bin Laden"
+        "poeta": "Mc Bin Laden",
+        "id": "vkJ5Lc0WwVw",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Você é tipo pantufa, em casa é gostosinha mas fora passo vergonha",
         "poesia": "Pensando em você",
-        "poeta": "Edy Lemond"
+        "poeta": "Edy Lemond",
+        "id": "nqusF20OpLc",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Nois é bom mas não é bombom",
         "poesia": "Ta Tranquilo Ta Favorável",
-        "poeta": "Mc Bin Laden"
+        "poeta": "Mc Bin Laden",
+        "id": "vkJ5Lc0WwVw",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Ta locona de pão de queijo?",
         "poesia": "Aham, Pode Pá",
-        "poeta": "Mc Bin Laden"
+        "poeta": "Mc Bin Laden",
+        "id": "b5xpz2EyKkY",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Quem é o teu homem? Vamo no cartório pra passa teu cu pro meu nome",
         "poesia": "Quem é o teu Homem",
-        "poeta": "Mc Maromba"
+        "poeta": "Mc Maromba",
+        "id": "CpKLRxtFzmI",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Toda obra prima tem a sua materia prima",
         "poesia": "Quer Ficar Grandão",
-        "poeta": "B-Dynamitze"
+        "poeta": "B-Dynamitze",
+        "id": "aitBMTUWNTk",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Quando a piroca tem dona é que vem a vontade de fuder",
         "poesia": "Mama",
-        "poeta": "Valesca Popozuda & Mr. Catra"
+        "poeta": "Valesca Popozuda & Mr. Catra",
+        "id": "Oc2B1JKRzQE",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Late mais alto que daqui eu não te escuto",
         "poesia": "Beijinho no Ombro",
-        "poeta": "Valesca Popozuda"
+        "poeta": "Valesca Popozuda",
+        "id": "73sbW7gjBeo",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Desejo a todas inimigas vida longa, para que elas vejam a cada dia nossa vitória",
         "poesia": "Beijinho no Ombro",
-        "poeta": "Valesca Popozuda"
+        "poeta": "Valesca Popozuda",
+        "id": "73sbW7gjBeo",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Todas que provaram, não conseguem esquecer.",
         "poesia": "Sou Foda",
-        "poeta": "Avassaladores"
+        "poeta": "Avassaladores",
+        "id": "RIBkK5X_3mo",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Eu sou sinistro, melhor que seu marido, esculacho seu amigo, no escuro eu sou um perigo.",
         "poesia": "Sou Foda",
-        "poeta": "Avassaladores"
+        "poeta": "Avassaladores",
+        "id": "RIBkK5X_3mo",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Um pente é pente",
         "poesia": "É o pente",
-        "poeta": "Os Hawaianos"
+        "poeta": "Os Hawaianos",
+        "id": "dEh3dJORNU4",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Traição é traição, romance é romance, amor é amor, e um lance é um lance",
         "poesia": "É o pente",
-        "poeta": "Os Hawaianos"
+        "poeta": "Os Hawaianos",
+        "id": "dEh3dJORNU4",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Não é culpa dela se o dedo dela não curte aliança",
         "poesia": "Amiga Parceira",
-        "poeta": "Pikeno & Menor"
+        "poeta": "Pikeno & Menor",
+        "id": "rlnEdfaEOhk",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Não tem nada pra fazer e fica nessa agonia, fala de mim, pensa em mim 24hrs por dia",
         "poesia": "24 Horas Por Dia",
-        "poeta": "Ludmilla"
+        "poeta": "Ludmilla",
+        "id": "3JCcTo5psps",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Sou cachorra sou gatinha não adianta se esquivar, vou soltar a minha fera, eu boto o bicho pra pegar",
         "poesia": "Boladona",
-        "poeta": "Tati Quebra Barraco"
+        "poeta": "Tati Quebra Barraco",
+        "id": "PA49hJlKRVo",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Me chama pra sair, olha que decepção, me leva pro cinema, pra assisti o Pokémon, se liga no papo reto que eu vo manda pra tu, eu quero é ir pro motel pra brinca com o Pikachu",
         "poesia": "Pikachu",
-        "poeta": "Tati Quebra Barraco"
+        "poeta": "Tati Quebra Barraco",
+        "id": "tHLocTShzfQ",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Açúcar o caralho, mamãe me passou pimenta, O Mulher quero ver se tu aguenta",
         "poesia": "Pimenta",
-        "poeta": "Biel"
+        "poeta": "Biel",
+        "id": "9AcATCPTzcA",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Deu mole na reta os moleque passa o cerol",
         "poesia": "Predador de Perereca",
-        "poeta" : "Mc Jhey"
+        "poeta": "Mc Jhey",
+        "id": "_QXwOaLbRyU",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Ai que vontade de ir pra praia... Já passou",
         "poesia": "O Verão Esta Chegando",
-        "poeta": "Mc Davi"
+        "poeta": "Mc Davi",
+        "id": "aio4Bc7ziXU",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Posta foto no iate mas não posta foto com o velhote que é dono",
         "poesia": "Famosinha do Instagram",
-        "poeta": "Mc Bin Laden"
+        "poeta": "Mc Bin Laden",
+        "id": "PZf1F1Euz98",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Ta locona de minecraft?",
         "poesia": "Famosinha do Instagram",
-        "poeta": "Mc Bin Laden"
+        "poeta": "Mc Bin Laden",
+        "id": "PZf1F1Euz98",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Gatinha assim você me assusta com o seu capô de fusca",
         "poesia": "Capô de Fusca",
-        "poeta": "Mr. Catra"
+        "poeta": "Mr. Catra",
+        "id": "JUSegDdVPqg",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Tem bulbasaur, tem mewtwo mas todo mundo quer pegar o meu pikachu",
         "poesia": "Pika Pika",
         "poeta": "Mc Troinha & Rei da Cacimbinha"
     },
-    {
+    {  
         "estrofe": "Você sabe o que é Cuquete? Se tu num sabe o que é Cuquete eu vô te apresentá! Cuquete é boquete mais com o cú que você vai pagá!",
         "poesia": "Cuquete",
-        "poeta": "Mr. Catra"
+        "poeta": "Mr. Catra",
+        "id": "A_vLheLOKvc",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "A maconha te engorda use crack que é mais light",
         "poesia": "Tô Usando Crack",
-        "poeta": "Mc Carol"
+        "poeta": "Mc Carol",
+        "id": "x4Ds3zrz748",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Eu quero tu vá, vá tomar no cu",
         "poesia": "Quero Que Tu Vá",
-        "poeta": "Ananda & Joker Beats"
+        "poeta": "Ananda & Joker Beats",
+        "id": "w_ejwSACf_U",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Na boca de quem não presta, quem é bom não vale nada",
         "poesia": "Um Brinde Pra Nós",
-        "poeta": "Mc Kapela & Mc PP da VS"
+        "poeta": "Mc Kapela & Mc PP da VS",
+        "id": "4ZZ1ivN2TA4",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Alô Alô mulherada sem caô, vai começar a sarrada no popô",
         "poesia": "Carga Nova",
-        "poeta": "Mc Urubuzinho"
+        "poeta": "Mc Urubuzinho",
+        "id": "rJOA7WyRRv8",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Tu já tomou no boga?",
         "poesia": "Vou Catucar seu Boga",
-        "poeta": "Mc Digu & Mc Keron"
+        "poeta": "Mc Digu & Mc Keron",
+        "id": "0Heucu2h14M",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "meu pipi começou a chorar, Disse que com teus lábios adorou dialogar",
         "poesia": "Na Ponta do Pé",
-        "poeta": "Mc Livinho"
+        "poeta": "Mc Livinho",
+        "id": "dj19l8u7kv4",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Hoje eu quero fuder, No instinto animal, Vou jogar minha buceta, Contraindo no teu pau",
         "poesia": "Brota na Base",
-        "poeta": "Mc Cachorrera"
+        "poeta": "Mc Cachorrera",
+        "id": "ZbZzLTvAw1g",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Quando é pra fuder essa mina pula até muro",
         "poesia": "Pula Muro",
-        "poeta": "Mc Magrinho"
+        "poeta": "Mc Magrinho",
+        "id": "0cCvTJs53tg",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Escama só de peixe",
         "poesia": "Envolvimento",
-        "poeta": "Mc Loma & as Gêmeas Lacração"
+        "poeta": "Mc Loma & as Gêmeas Lacração",
+        "id": "dg26JUz3A5s",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Amor, a culpa não é minha. Amor, é das tuas amiguinhas. Eu tava ligado e cansei de te avisar: amiga é o caralho, todas querem me dar",
         "poesia": "A Culpa Não É Minha",
-        "poeta": "Mc Dino"
+        "poeta": "Mc Dino",
+        "id": "8YfRm1ZpgHM",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Se eu tiver solteiro não vou perdoar ninguém, Suas amiga putiane eu vou comer também",
         "poesia": "Se Eu Tiver Solteiro",
-        "poeta": "Mc Don Juan"
+        "poeta": "Mc Don Juan",
+        "id": "e5_xENXFEhE",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Com a irmã do parça, Vem, que lá na casa dele, É motel de graça",
         "poesia": "Se Eu Tiver Solteiro",
-        "poeta": "Mc Livinho & Mc Davi"
+        "poeta": "Mc Livinho & Mc Davi",
+        "id": "mkrgyjC0c0Q",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Pra muitos o mundo é grande, mas minha missão é maior que o mundo",
         "poesia": "Malandrão",
-        "poeta": "Mc Brinquedo"
+        "poeta": "Mc Brinquedo",
+        "id": "8BA877k2KvM",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Uma garrafa é pouco Jack ou Buchanan's tanto faz. Whisky com gelo de coco sempre deixando os problemas pra trás.",
         "poesia": "Esse Mlk Tá Um Nojo",
-        "poeta": "Mc Léo da Baixada"
+        "poeta": "Mc Léo da Baixada",
+        "id": "oZpWVwpRS9g",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Vai começar a putaria",
         "poesia": "Vai começar a putaria",
-        "poeta": "Mr. Catra"
+        "poeta": "Mr. Catra",
+        "id": "MONXkMLEfjI",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Uh papai chegou . uh uh papai chegou Uh papai chegou . uh uh papai chegou",
         "poesia": "Uh Papai Chegou",
-        "poeta": "Mr. Catra"
+        "poeta": "Mr. Catra",
+        "id": "sZxT4BOXPFc",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "A pista já tava com muita saudade de mim! Ó quem voltou pra sacanagm.",
         "poesia": "Oh Quem Voltou",
-        "poeta": "Dani Russo"
+        "poeta": "Dani Russo",
+        "id": "jjdTRQ_CiFA",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Vai me enterrar na areia? Não, não, vou atolar.",
         "poesia": "Atoladinha",
-        "poeta": "Bola de fogo"
+        "poeta": "Bola de fogo",
+        "id": "Nk6r9EmePxs",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "A vida é tipo roda gigante, então pra quê esculhacho? Se hoje está em cima, amanhã tá embaixo.",
         "poesia": "A Vida É Tipo Roda Gigante",
-        "poeta": "Mc Andrezinho Shock"
+        "poeta": "Mc Andrezinho Shock",
+        "id": "D5FZs3OJzR0",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Dei uma de maluco, prendi a respiração dei uma linguada estava cheio de sal",
         "poesia": "Cheio de Sal",
-        "poeta": "Mc Gorilla"
+        "poeta": "Mc Gorilla",
+        "id": "N4Q4j1oSdUU",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "A novinha não me quer, só porque eu vim da roça",
         "poesia": "Roça Roça",
-        "poeta": "Mc Brinquedo"
+        "poeta": "Mc Brinquedo",
+        "id": "y3UVdkWsk8s",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Dom Dom Dom, Dom Dom Dom, a novinha experiente já nasceu com esse dom",
         "poesia": "A Novinha Experiente ja Nasceu Com esse Dom",
-        "poeta": "Mc Magrinho & Mc Pedrinho"
+        "poeta": "Mc Magrinho & Mc Pedrinho",
+        "id": "0cCvTJs53tg",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Avara Ké-raba, arrasta a tabaca na vara vai sentando na vassoura, eita bruxinha rabuda, eita rabeta que voa",
         "poesia": "Harry Porra e a Bruxinha Rabuda",
-        "poeta": "Mc Maha"
+        "poeta": "Mc Maha",
+        "id": "0i5EdFHDlHo",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Namorar pra quê? Se amarrar pra quê? Prefiro tá solteiro que eu sei que elas vão querer.",
         "poesia": "Namorar Pra Quê?",
-        "poeta": "Mc Kekeu"
+        "poeta": "Mc Kekeu",
+        "id": "byXfKMEmVZc",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "É a flauta envolvente, que mexe com a mente, de quem tá presente",
         "poesia": "Bum Bum Tam Tam",
-        "poeta": "Mc Fioti"
+        "poeta": "Mc Fioti",
+        "id": "S3igAR77ifc",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Tô bonito, tô né? Quem mandou tu terminar?",
         "poesia": "Quem Mandou Tu Terminar",
-        "poeta": "Mc Kekel"
+        "poeta": "Mc Kekel",
+        "id": "NgK9fe45bJA",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Se teu hobby é sentar, não vou te criticar, tá de parabéns",
         "poesia": "Fazer Falta",
-        "poeta": "Mc Livinho"
+        "poeta": "Mc Livinho",
+        "id": "b9jo4mk0VQU",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Quando a gente ama não vemos defeito, ela é a dona do meu cora... Porra nenhuma eu quero é putaria",
         "poesia": "Uh Papai Chegou",
-        "poeta": "Mr. Catra"
+        "poeta": "Mr. Catra",
+        "id": "sZxT4BOXPFc",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "I love you too cu, então senta no piru",
         "poesia": "Open The Tcheka",
-        "poeta": "Mc Lan"
+        "poeta": "Mc Lan",
+        "id": "OQNFJKMH8bo",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Raidenosfri garurreim garulol, Pantianaru lololololololol",
         "poesia": "Pica Né?",
-        "poeta": "Mc Biriri"
+        "poeta": "Mc Biriri",
+        "id": "MiEt2maqCU0",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Quer andar de meiota, senta na minha piroca",
         "poesia": "Meiota",
-        "poeta": "Mc Kekel"
+        "poeta": "Mc Kekel",
+        "id": "AXGz_xYIsFA",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Eu vou fazer uma serenata, só pra te ver dançar pelada",
         "poesia": "Rabetão",
-        "poeta": "Mc Lan"
+        "poeta": "Mc Lan",
+        "id": "RymhzC238YI",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "No escuro da tua inveja, a minha luz é neon",
         "poesia": "Paralisa",
-        "poeta": "Mc Loma & as Gêmeas Lacração & Mc WM"
+        "poeta": "Mc Loma & as Gêmeas Lacração & Mc WM",
+        "id": "dg26JUz3A5s",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Deixa esse teu rancor de lado. E vem aqui me dar um beijo, matar meu desejo.",
         "poesia": "Você Não Colabora",
-        "poeta": "Mc Rodrigo do CN"
+        "poeta": "Mc Rodrigo do CN",
+        "id": "bdS2GeV6aR8",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Diretamente de Hogwarts, Wingardium Levirola.",
         "poesia": "Harry Porra e a Bruxinha Rabuda",
-        "poeta": "Mc Maha"
+        "poeta": "Mc Maha",
+        "id": "0i5EdFHDlHo",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Quem nasceu pra ser cu nunca vai ser pica",
         "poesia": "Os Caras do Momento",
-        "poeta": "Mc Nego do Borel"
+        "poeta": "Mc Nego do Borel",
+        "id": "NgB6N5_Jw4w",
+        "start": 0
     },
-    {
+    {  
         "estrofe": "Perereca suicida, se joga na pica, se mata na pica",
         "poesia": "Perereca suicida",
-        "poeta": "Mc Japa"
+        "poeta": "Mc Japa",
+        "id": "mwcg0UJa_mw",
+        "start": 0
     }
 ]

--- a/poesias.json
+++ b/poesias.json
@@ -310,7 +310,7 @@
         "poesia": "Cheio de Sal",
         "poeta": "Mc Gorilla",
         "id": "N4Q4j1oSdUU",
-        "start": 0
+        "start": 41
     },
     {  
         "estrofe": "A novinha não me quer, só porque eu vim da roça",

--- a/poesias.json
+++ b/poesias.json
@@ -1,430 +1,430 @@
 [  
-    {  
+    {
         "estrofe": "Foca mas não sufoca",
         "poesia": "Ta Tranquilo Ta Favorável",
         "poeta": "Mc Bin Laden",
         "id": "vkJ5Lc0WwVw",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Você é tipo pantufa, em casa é gostosinha mas fora passo vergonha",
         "poesia": "Pensando em você",
         "poeta": "Edy Lemond",
         "id": "nqusF20OpLc",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Nois é bom mas não é bombom",
         "poesia": "Ta Tranquilo Ta Favorável",
         "poeta": "Mc Bin Laden",
         "id": "vkJ5Lc0WwVw",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Ta locona de pão de queijo?",
         "poesia": "Aham, Pode Pá",
         "poeta": "Mc Bin Laden",
         "id": "b5xpz2EyKkY",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Quem é o teu homem? Vamo no cartório pra passa teu cu pro meu nome",
         "poesia": "Quem é o teu Homem",
         "poeta": "Mc Maromba",
         "id": "CpKLRxtFzmI",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Toda obra prima tem a sua materia prima",
         "poesia": "Quer Ficar Grandão",
         "poeta": "B-Dynamitze",
         "id": "aitBMTUWNTk",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Quando a piroca tem dona é que vem a vontade de fuder",
         "poesia": "Mama",
         "poeta": "Valesca Popozuda & Mr. Catra",
         "id": "Oc2B1JKRzQE",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Late mais alto que daqui eu não te escuto",
         "poesia": "Beijinho no Ombro",
         "poeta": "Valesca Popozuda",
         "id": "73sbW7gjBeo",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Desejo a todas inimigas vida longa, para que elas vejam a cada dia nossa vitória",
         "poesia": "Beijinho no Ombro",
         "poeta": "Valesca Popozuda",
         "id": "73sbW7gjBeo",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Todas que provaram, não conseguem esquecer.",
         "poesia": "Sou Foda",
         "poeta": "Avassaladores",
         "id": "RIBkK5X_3mo",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Eu sou sinistro, melhor que seu marido, esculacho seu amigo, no escuro eu sou um perigo.",
         "poesia": "Sou Foda",
         "poeta": "Avassaladores",
         "id": "RIBkK5X_3mo",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Um pente é pente",
         "poesia": "É o pente",
         "poeta": "Os Hawaianos",
         "id": "dEh3dJORNU4",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Traição é traição, romance é romance, amor é amor, e um lance é um lance",
         "poesia": "É o pente",
         "poeta": "Os Hawaianos",
         "id": "dEh3dJORNU4",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Não é culpa dela se o dedo dela não curte aliança",
         "poesia": "Amiga Parceira",
         "poeta": "Pikeno & Menor",
         "id": "rlnEdfaEOhk",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Não tem nada pra fazer e fica nessa agonia, fala de mim, pensa em mim 24hrs por dia",
         "poesia": "24 Horas Por Dia",
         "poeta": "Ludmilla",
         "id": "3JCcTo5psps",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Sou cachorra sou gatinha não adianta se esquivar, vou soltar a minha fera, eu boto o bicho pra pegar",
         "poesia": "Boladona",
         "poeta": "Tati Quebra Barraco",
         "id": "PA49hJlKRVo",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Me chama pra sair, olha que decepção, me leva pro cinema, pra assisti o Pokémon, se liga no papo reto que eu vo manda pra tu, eu quero é ir pro motel pra brinca com o Pikachu",
         "poesia": "Pikachu",
         "poeta": "Tati Quebra Barraco",
         "id": "tHLocTShzfQ",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Açúcar o caralho, mamãe me passou pimenta, O Mulher quero ver se tu aguenta",
         "poesia": "Pimenta",
         "poeta": "Biel",
         "id": "9AcATCPTzcA",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Deu mole na reta os moleque passa o cerol",
         "poesia": "Predador de Perereca",
         "poeta": "Mc Jhey",
         "id": "_QXwOaLbRyU",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Ai que vontade de ir pra praia... Já passou",
         "poesia": "O Verão Esta Chegando",
         "poeta": "Mc Davi",
         "id": "aio4Bc7ziXU",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Posta foto no iate mas não posta foto com o velhote que é dono",
         "poesia": "Famosinha do Instagram",
         "poeta": "Mc Bin Laden",
         "id": "PZf1F1Euz98",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Ta locona de minecraft?",
         "poesia": "Famosinha do Instagram",
         "poeta": "Mc Bin Laden",
         "id": "PZf1F1Euz98",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Gatinha assim você me assusta com o seu capô de fusca",
         "poesia": "Capô de Fusca",
         "poeta": "Mr. Catra",
         "id": "JUSegDdVPqg",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Tem bulbasaur, tem mewtwo mas todo mundo quer pegar o meu pikachu",
         "poesia": "Pika Pika",
         "poeta": "Mc Troinha & Rei da Cacimbinha"
     },
-    {  
+    {
         "estrofe": "Você sabe o que é Cuquete? Se tu num sabe o que é Cuquete eu vô te apresentá! Cuquete é boquete mais com o cú que você vai pagá!",
         "poesia": "Cuquete",
         "poeta": "Mr. Catra",
         "id": "A_vLheLOKvc",
         "start": 0
     },
-    {  
+    {
         "estrofe": "A maconha te engorda use crack que é mais light",
         "poesia": "Tô Usando Crack",
         "poeta": "Mc Carol",
         "id": "x4Ds3zrz748",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Eu quero tu vá, vá tomar no cu",
         "poesia": "Quero Que Tu Vá",
         "poeta": "Ananda & Joker Beats",
         "id": "w_ejwSACf_U",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Na boca de quem não presta, quem é bom não vale nada",
         "poesia": "Um Brinde Pra Nós",
         "poeta": "Mc Kapela & Mc PP da VS",
         "id": "4ZZ1ivN2TA4",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Alô Alô mulherada sem caô, vai começar a sarrada no popô",
         "poesia": "Carga Nova",
         "poeta": "Mc Urubuzinho",
         "id": "rJOA7WyRRv8",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Tu já tomou no boga?",
         "poesia": "Vou Catucar seu Boga",
         "poeta": "Mc Digu & Mc Keron",
         "id": "0Heucu2h14M",
         "start": 0
     },
-    {  
+    {
         "estrofe": "meu pipi começou a chorar, Disse que com teus lábios adorou dialogar",
         "poesia": "Na Ponta do Pé",
         "poeta": "Mc Livinho",
         "id": "dj19l8u7kv4",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Hoje eu quero fuder, No instinto animal, Vou jogar minha buceta, Contraindo no teu pau",
         "poesia": "Brota na Base",
         "poeta": "Mc Cachorrera",
         "id": "ZbZzLTvAw1g",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Quando é pra fuder essa mina pula até muro",
         "poesia": "Pula Muro",
         "poeta": "Mc Magrinho",
         "id": "0cCvTJs53tg",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Escama só de peixe",
         "poesia": "Envolvimento",
         "poeta": "Mc Loma & as Gêmeas Lacração",
         "id": "dg26JUz3A5s",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Amor, a culpa não é minha. Amor, é das tuas amiguinhas. Eu tava ligado e cansei de te avisar: amiga é o caralho, todas querem me dar",
         "poesia": "A Culpa Não É Minha",
         "poeta": "Mc Dino",
         "id": "8YfRm1ZpgHM",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Se eu tiver solteiro não vou perdoar ninguém, Suas amiga putiane eu vou comer também",
         "poesia": "Se Eu Tiver Solteiro",
         "poeta": "Mc Don Juan",
         "id": "e5_xENXFEhE",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Com a irmã do parça, Vem, que lá na casa dele, É motel de graça",
         "poesia": "Se Eu Tiver Solteiro",
         "poeta": "Mc Livinho & Mc Davi",
         "id": "mkrgyjC0c0Q",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Pra muitos o mundo é grande, mas minha missão é maior que o mundo",
         "poesia": "Malandrão",
         "poeta": "Mc Brinquedo",
         "id": "8BA877k2KvM",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Uma garrafa é pouco Jack ou Buchanan's tanto faz. Whisky com gelo de coco sempre deixando os problemas pra trás.",
         "poesia": "Esse Mlk Tá Um Nojo",
         "poeta": "Mc Léo da Baixada",
         "id": "oZpWVwpRS9g",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Vai começar a putaria",
         "poesia": "Vai começar a putaria",
         "poeta": "Mr. Catra",
         "id": "MONXkMLEfjI",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Uh papai chegou . uh uh papai chegou Uh papai chegou . uh uh papai chegou",
         "poesia": "Uh Papai Chegou",
         "poeta": "Mr. Catra",
         "id": "sZxT4BOXPFc",
         "start": 0
     },
-    {  
+    {
         "estrofe": "A pista já tava com muita saudade de mim! Ó quem voltou pra sacanagm.",
         "poesia": "Oh Quem Voltou",
         "poeta": "Dani Russo",
         "id": "jjdTRQ_CiFA",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Vai me enterrar na areia? Não, não, vou atolar.",
         "poesia": "Atoladinha",
         "poeta": "Bola de fogo",
         "id": "Nk6r9EmePxs",
         "start": 0
     },
-    {  
+    {
         "estrofe": "A vida é tipo roda gigante, então pra quê esculhacho? Se hoje está em cima, amanhã tá embaixo.",
         "poesia": "A Vida É Tipo Roda Gigante",
         "poeta": "Mc Andrezinho Shock",
         "id": "D5FZs3OJzR0",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Dei uma de maluco, prendi a respiração dei uma linguada estava cheio de sal",
         "poesia": "Cheio de Sal",
         "poeta": "Mc Gorilla",
         "id": "N4Q4j1oSdUU",
         "start": 41
     },
-    {  
+    {
         "estrofe": "A novinha não me quer, só porque eu vim da roça",
         "poesia": "Roça Roça",
         "poeta": "Mc Brinquedo",
         "id": "y3UVdkWsk8s",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Dom Dom Dom, Dom Dom Dom, a novinha experiente já nasceu com esse dom",
         "poesia": "A Novinha Experiente ja Nasceu Com esse Dom",
         "poeta": "Mc Magrinho & Mc Pedrinho",
         "id": "0cCvTJs53tg",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Avara Ké-raba, arrasta a tabaca na vara vai sentando na vassoura, eita bruxinha rabuda, eita rabeta que voa",
         "poesia": "Harry Porra e a Bruxinha Rabuda",
         "poeta": "Mc Maha",
         "id": "0i5EdFHDlHo",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Namorar pra quê? Se amarrar pra quê? Prefiro tá solteiro que eu sei que elas vão querer.",
         "poesia": "Namorar Pra Quê?",
         "poeta": "Mc Kekeu",
         "id": "byXfKMEmVZc",
         "start": 0
     },
-    {  
+    {
         "estrofe": "É a flauta envolvente, que mexe com a mente, de quem tá presente",
         "poesia": "Bum Bum Tam Tam",
         "poeta": "Mc Fioti",
         "id": "S3igAR77ifc",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Tô bonito, tô né? Quem mandou tu terminar?",
         "poesia": "Quem Mandou Tu Terminar",
         "poeta": "Mc Kekel",
         "id": "NgK9fe45bJA",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Se teu hobby é sentar, não vou te criticar, tá de parabéns",
         "poesia": "Fazer Falta",
         "poeta": "Mc Livinho",
         "id": "b9jo4mk0VQU",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Quando a gente ama não vemos defeito, ela é a dona do meu cora... Porra nenhuma eu quero é putaria",
         "poesia": "Uh Papai Chegou",
         "poeta": "Mr. Catra",
         "id": "sZxT4BOXPFc",
         "start": 0
     },
-    {  
+    {
         "estrofe": "I love you too cu, então senta no piru",
         "poesia": "Open The Tcheka",
         "poeta": "Mc Lan",
         "id": "OQNFJKMH8bo",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Raidenosfri garurreim garulol, Pantianaru lololololololol",
         "poesia": "Pica Né?",
         "poeta": "Mc Biriri",
         "id": "MiEt2maqCU0",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Quer andar de meiota, senta na minha piroca",
         "poesia": "Meiota",
         "poeta": "Mc Kekel",
         "id": "AXGz_xYIsFA",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Eu vou fazer uma serenata, só pra te ver dançar pelada",
         "poesia": "Rabetão",
         "poeta": "Mc Lan",
         "id": "RymhzC238YI",
         "start": 0
     },
-    {  
+    {
         "estrofe": "No escuro da tua inveja, a minha luz é neon",
         "poesia": "Paralisa",
         "poeta": "Mc Loma & as Gêmeas Lacração & Mc WM",
         "id": "dg26JUz3A5s",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Deixa esse teu rancor de lado. E vem aqui me dar um beijo, matar meu desejo.",
         "poesia": "Você Não Colabora",
         "poeta": "Mc Rodrigo do CN",
         "id": "bdS2GeV6aR8",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Diretamente de Hogwarts, Wingardium Levirola.",
         "poesia": "Harry Porra e a Bruxinha Rabuda",
         "poeta": "Mc Maha",
         "id": "0i5EdFHDlHo",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Quem nasceu pra ser cu nunca vai ser pica",
         "poesia": "Os Caras do Momento",
         "poeta": "Mc Nego do Borel",
         "id": "NgB6N5_Jw4w",
         "start": 0
     },
-    {  
+    {
         "estrofe": "Perereca suicida, se joga na pica, se mata na pica",
         "poesia": "Perereca suicida",
         "poeta": "Mc Japa",


### PR DESCRIPTION
Esse PR possibilita tocar a música em plano de fundo.

foram adicionadas as chaves `id` e `start` no arquivo `poesias.json` que correspondem respectivamente ao id do vídeo no youtube, e o momento que a frase começa.

o start foi setado como 0 porque essa tarefa eu não consegui automatizar.

os ids eu peguei com [esse](https://gist.github.com/giancarlopro/84d658bf9c67fecae3a86905fe400fa4) script em python que pega o primeiro id da pesquisa feita utilizando a soma dos valores de poeta e poesia.

Issue #11 