### PR TITLE
Arrumando o arquivo inválido poesias.json / Fix invalid poesias.json

### DIFF
--- a/poesias.json
+++ b/poesias.json
@@ -995,10 +995,9 @@
    },
    {
       "estrofe": "Não adianta tu se declarar, romance e compromisso comigo não rola",
-            "poesia": "Te Amo Sem Compromisso",
-            "poeta": "Mc Doni",
-            "youtubeId": "zEE77Flhr9Y",
-            "startTime": 16
-        }
+      "poesia": "Te Amo Sem Compromisso",
+      "poeta": "Mc Doni",
+      "youtubeId": "zEE77Flhr9Y",
+      "startTime": 16
    }
 ]


### PR DESCRIPTION
[PT-BR]

Depois do merge dessa PR, o arquivo `poesias.json` se tornou inválido pois existe um colchete sobrando ali no fim.

Ref https://github.com/IgorRozani/filosofunk/pull/111

[EN]

After merging the PR above mentioned, the file `poesias.json` became invalid due to an extra curly braces at the end.